### PR TITLE
Fix timestamp reporting to show fractional seconds correctly

### DIFF
--- a/cpp-lowlevelsdk/main.cpp
+++ b/cpp-lowlevelsdk/main.cpp
@@ -1,15 +1,15 @@
-//
-// Created by connor on 3/6/25.
-//
-
 #include "client.hpp"
 #include <iostream>
 
 int main() {
     OSLowLevelSdkClient client("INSERT_CONTROLLER_IP_HERE:50099");
+
+    std::cout.precision(20);
+
     // 0 minimumIntervalMicroseconds yields a message as soon as it's available
     client.StreamObservatoryStatus(0, 1000, [](oslowlevelsdk::V1ObservatoryStatus status) {
-        std::cout << "Timestamp: " << status.timestamp().seconds()  << "." << status.timestamp().nanos() << std::endl;
+        double timestampSecondsSince1970 = status.timestamp().seconds() + (status.timestamp().nanos() / 1000000000.0);
+        std::cout << "Timestamp: " << timestampSecondsSince1970 << std::endl;
         std::cout << "Primary Mount Encoder: " << status.encoder_mount_primary_radians() << " radians" << std::endl;
         std::cout << "Secondary Mount Encoder: " << status.encoder_mount_secondary_radians() << " radians" << std::endl;
         std::cout << "------------------------------------" << std::endl;


### PR DESCRIPTION
Avoid zero-padding issues in the nanoseconds field. 

Note that by converting to a double (15-17 total digits accurately represented, with 10 digits before the decimal point), our converted time value is only good to about the microsecond level. It may be better to zero-pad the nanoseconds field and print it separately instead, but converting to double makes time math easier if you want to do that within the program.